### PR TITLE
fix: return snapshot copy from UpdateResource to prevent store aliasing

### DIFF
--- a/backend/internal/core/kubernetes/kubeStoreImpl.go
+++ b/backend/internal/core/kubernetes/kubeStoreImpl.go
@@ -261,7 +261,9 @@ func (k *KubeStoreImpl) UpdateResource(newResource Resource) *Resource {
 			k.resourcesRefs[selfRef] = []*Resource{}
 		}
 		k.registerParentRefs(&newResource)
-		return &newResource
+		snapshot := Resource{}
+		snapshot.Copy(newResource)
+		return &snapshot
 	}
 
 	logger.Debug("Resource found, updated existing resource")
@@ -288,7 +290,9 @@ func (k *KubeStoreImpl) UpdateResource(newResource Resource) *Resource {
 	}
 
 	k.registerParentRefs(updated)
-	return updated
+	snapshot := Resource{}
+	snapshot.Copy(*updated)
+	return &snapshot
 }
 
 func (k *KubeStoreImpl) GetKnownResourceAPIRefs() map[string]struct{} {


### PR DESCRIPTION
Callers received a pointer into store-internal state, allowing mutation outside the mutex. Both return paths now copy into a fresh snapshot.